### PR TITLE
return a definitive answer on GetParameters

### DIFF
--- a/internal/ccid/get_parameters.go
+++ b/internal/ccid/get_parameters.go
@@ -44,7 +44,3 @@ func (cmd *GetParameters) Handle(_ []byte, _ *icc.Interface) ([]byte, error) {
 
 	return Serialize(res)
 }
-
-
-	return Serialize(res)
-}

--- a/internal/ccid/get_parameters.go
+++ b/internal/ccid/get_parameters.go
@@ -38,8 +38,13 @@ func (cmd *GetParameters) Handle(_ []byte, _ *icc.Interface) ([]byte, error) {
 		MessageType: PARAMETERS,
 		Slot:        cmd.Slot,
 		Seq:         cmd.Seq,
-		Status:      FAILED,
+		Status:      ICC_PRESENT_AND_ACTIVE,
+		ProtocolNum: 0x01, // indicate use of T=1
 	}
+
+	return Serialize(res)
+}
+
 
 	return Serialize(res)
 }


### PR DESCRIPTION
Windows relies on this call. Avoid the "FAILED" response and indicate T=1 block transmission as selected mode in any case the parameters are accessed. T=1 is the preferable way to go. If you change the ATR of the card to emulate to T=0-only then adjust the ProtocolNum here to ensure correct protocol behaviour on the host operating system.